### PR TITLE
Add checks, update HCP Packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Default Packer bucket name matches the Ubuntu 22.04 Nginx image built with my [P
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
-| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.62 |
+| <a name="requirement_hcp"></a> [hcp](#requirement\_hcp) | ~> 0.82 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
@@ -20,11 +20,11 @@ Default Packer bucket name matches the Ubuntu 22.04 Nginx image built with my [P
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.5.0 |
-| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | 0.62.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_hcp"></a> [hcp](#provider\_hcp) | ~> 0.82 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 
@@ -48,8 +48,7 @@ No modules.
 | [null_resource.configure-web-app](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_integer.product](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
 | [tls_private_key.hashicafe](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [hcp_packer_image.ubuntu-webserver](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/data-sources/packer_image) | data source |
-| [hcp_packer_iteration.ubuntu-webserver](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/data-sources/packer_iteration) | data source |
+| [hcp_packer_artifact.ubuntu-webserver](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/data-sources/packer_artifact) | data source |
 
 ## Inputs
 

--- a/checks.tf
+++ b/checks.tf
@@ -12,11 +12,11 @@ check "web_health" {
     error_message = "The EC2 instance is not running."
   }
   assert {
-    condition     = data.hcp_packer_image.ubuntu-webserver.revoke_at == null
+    condition     = data.hcp_packer_artifact.ubuntu-webserver.revoke_at == null
     error_message = "The image referenced in the Packer bucket is scheduled for revocation."
   }
   assert {
-    condition     = timecmp(plantimestamp(), timeadd(data.hcp_packer_image.ubuntu-webserver.created_at, "720h")) < 0
+    condition     = timecmp(plantimestamp(), timeadd(data.hcp_packer_artifact.ubuntu-webserver.created_at, "720h")) < 0
     error_message = "The image referenced in the Packer bucket is more than 30 days old."
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.62"
+      version = "~> 0.82"
     }
     null = {
       source  = "hashicorp/null"
@@ -43,11 +43,11 @@ resource "random_integer" "product" {
   max = length(var.hashi_products) - 1
 }
 
-data "hcp_packer_image" "ubuntu-webserver" {
-  bucket_name    = var.packer_bucket
-  channel        = var.packer_channel
-  cloud_provider = "aws"
-  region         = var.region
+data "hcp_packer_artifact" "ubuntu-webserver" {
+  bucket_name  = var.packer_bucket
+  channel_name = var.packer_channel
+  platform     = "aws"
+  region       = var.region
 }
 
 resource "aws_vpc" "hashicafe" {
@@ -127,7 +127,7 @@ resource "aws_route_table_association" "hashicafe" {
 }
 
 resource "aws_instance" "hashicafe" {
-  ami                         = data.hcp_packer_image.ubuntu-webserver.cloud_image_id
+  ami                         = data.hcp_packer_artifact.ubuntu-webserver.external_identifier
   instance_type               = var.instance_type
   associate_public_ip_address = true
   subnet_id                   = aws_subnet.hashicafe.id
@@ -140,7 +140,7 @@ resource "aws_instance" "hashicafe" {
 
   lifecycle {
     precondition {
-      condition     = data.hcp_packer_image.ubuntu-webserver.region == var.region
+      condition     = data.hcp_packer_artifact.ubuntu-webserver.region == var.region
       error_message = "The selected image must be in the same region as the deployed resources."
     }
 


### PR DESCRIPTION
Several updates:
* Adds checks (TF 1.5 required).
* Removes the timestamp keeper from the random product selector. This introduced perpetual drift.
* Update to the new HCP Packer `hcp_packer_artifact` resource.